### PR TITLE
Add API root view to test_app

### DIFF
--- a/test_app/README.md
+++ b/test_app/README.md
@@ -11,6 +11,7 @@ If you are attempting to start test_app for the first time in a fresh environmen
 
 ```
 pip install -r requirements/requirements_all.txt
+pip install -r test_app/requirements.txt
 ```
 
 # Initialize the test app

--- a/test_app/requirements.txt
+++ b/test_app/requirements.txt
@@ -1,0 +1,2 @@
+django-extensions
+sdb

--- a/test_app/settings.py
+++ b/test_app/settings.py
@@ -46,6 +46,7 @@ INSTALLED_APPS = [
     'ansible_base.resource_registry',
     'ansible_base.rbac',
     'test_app',
+    'django_extensions',
 ]
 
 MIDDLEWARE = [

--- a/test_app/urls.py
+++ b/test_app/urls.py
@@ -4,6 +4,7 @@ from django.urls import include, path, re_path
 from ansible_base.lib.dynamic_config.dynamic_urls import api_urls, api_version_urls, root_urls
 from ansible_base.resource_registry.urls import urlpatterns as resource_api_urls
 from test_app.router import router as test_app_router
+from test_app import views
 
 urlpatterns = [
     path('api/v1/', include(api_version_urls)),
@@ -14,4 +15,6 @@ urlpatterns = [
     # Admin application
     re_path(r"^admin/", admin.site.urls, name="admin"),
     path('api/v1/', include(resource_api_urls)),
+    path('api/v1/', views.api_root),
+    path('login/', include('rest_framework.urls')),
 ]

--- a/test_app/views.py
+++ b/test_app/views.py
@@ -1,4 +1,6 @@
 from rest_framework import permissions
+from rest_framework.decorators import api_view
+from rest_framework.reverse import reverse
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
@@ -61,3 +63,19 @@ class CowViewSet(TestAppViewSet):
 
 class UUIDModelViewSet(TestAppViewSet):
     serializer_class = serializers.UUIDModelSerializer
+
+
+# create api root view from the router
+@api_view(['GET'])
+def api_root(request, format=None):
+    return Response({
+        'organizations': reverse('organization-list', request=request, format=format),
+        'teams': reverse('team-list', request=request, format=format),
+        'users': reverse('user-list', request=request, format=format),
+        'inventories': reverse('inventory-list', request=request, format=format),
+        'cows': reverse('cow-list', request=request, format=format),
+        'uuidmodels': reverse('uuidmodel-list', request=request, format=format),
+        'role_user_assignments': reverse('roleuserassignment-list', request=request, format=format),
+        'role_team_assignments': reverse('roleteamassignment-list', request=request, format=format),
+        'role_definitions': reverse('roledefinition-list', request=request, format=format),
+    })


### PR DESCRIPTION
lists endpoints at api/v1/

Also:

- adds a login button on the DRF pages

- enables django-extensions for shell_plus
- 
![Screenshot from 2024-02-29 15-45-05](https://github.com/AlanCoding/django-ansible-base/assets/8745776/fc7ffbb6-950e-48d6-9fb1-8e3b0459a9ca)
